### PR TITLE
1.1.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,5 @@ jobs:
     docker: 
       - image: circleci/node
     steps:
-      - run: exit 0
+      - run: exit 0 #toggle this to force success or status for testing
       - slack/status

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  slack: sandbox/slack@dev:1.1.0
+  slack: sandbox/slack@1.1.0
 jobs:
   build:
     docker: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
-  slack: sandbox/slack@dev:0.2.32
- #testing without webhook
+  slack: sandbox/slack@dev:1.1.0
 jobs:
   build:
     docker: 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,5 @@ jobs:
       - image: circleci/node
     steps:
       - run: exit 0 #toggle this to force success or status for testing
-      - slack/status
+      - slack/status:
           fail_only: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,3 +8,4 @@ jobs:
     steps:
       - run: exit 0 #toggle this to force success or status for testing
       - slack/status
+          fail_only: "true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,5 +7,4 @@ jobs:
       - image: circleci/node
     steps:
       - run: exit 0 #toggle this to force success or status for testing
-      - slack/status:
-          fail_only: "true"
+      - slack/status

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ jobs:
 |  Usage | slack/status   |
 | ------------ | ------------ |
 | **Description:**  | Send a status alert at the end of a job based on success or failure. Must be last step in job  |   
-|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable|
+|  **Parameters:** | -  **webhook:** Enter either your Webhook value or use the CircleCI UI to add your token under the `SLACK_WEBHOOK` environment variable <br> <br> -  **fail_only:** `false` by default. If set to `true, successful jobs will _not_ send alerts |
+
+
 
 TODO:
 
 | Task | Status |
 | ------------ | ------------ |
 | Allow option of tagging users| 0% |
-| Make skipping success messages on `status` optional | 0% |
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+# 1.0.0: 10/16/2018
+* First release with two functions. Send a custom message with `slack/notify` or receive status updates with `slack/status` when your jobs complete.
+* Docs created
+
+## 1.1.0: 10/xx/2018
+* Allow suppression of successful messages with new parameter 'fail_only' when set to 'true'.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 * First release with two functions. Send a custom message with `slack/notify` or receive status updates with `slack/status` when your jobs complete.
 * Docs created
 
-## 1.1.0: 10/xx/2018
+## 1.1.0: 10/16/2018
 * Allow suppression of successful messages with new parameter 'fail_only' when set to 'true'.
 * Updated Alert job name to no longer imply the alert has already been sent
 * Reflect status in shell as well as webhook

--- a/changelog.md
+++ b/changelog.md
@@ -4,3 +4,5 @@
 
 ## 1.1.0: 10/xx/2018
 * Allow suppression of successful messages with new parameter 'fail_only' when set to 'true'.
+* Updated Alert job name to no longer imply the alert has already been sent
+* Reflect status in shell as well as webhook

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
-#slack orb 0.2.32
+#slack orb dev:1.1.0
 #Create your key here: https://api.slack.com/incoming-webhooks
 orbs:
 description: A notification orb for slack. Submit messages to your slack channels.
@@ -37,6 +37,10 @@ commands:
         description: Enter either your Webhook value or use the CircleCI UI to add your token under the 'SLACK_WEBHOOK' env var
         type: string
         default: ${SLACK_WEBHOOK}
+      fail_only:
+        description: If 'true', notifications successful jobs will not be sent
+        type: string
+        default: "false"
     steps:
       - run:
           name: Slack - Setting Failure Condition
@@ -57,9 +61,14 @@ commands:
               echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."
               exit 1
             else
+              #If successful
               if [ "$SLACK_BUILD_STATUS" = "success" ]; then
-                #If successful
-                curl -X POST -H 'Content-type: application/json' --data '{ "attachments": [ { "fallback": "Job completed successfully - '$CIRCLE_BUILD_URL'", "text": "Job has completed successfully", "fields": [ { "title": "Project", "value": "'$CIRCLE_PROJECT_REPONAME'", "short": true }, { "title": "Job Number", "value": "'$CIRCLE_BUILD_NUM'", "short": true } ], "actions": [ { "type": "button", "text": "Visit Job", "url": "'$CIRCLE_BUILD_URL'" } ], "color": "#1CBF43" } ] }' << parameters.webhook >>
+                if [ << parameters.webhook >> = "true"]; then
+                  echo The job completed successfully
+                  echo '"fail_only" is set to "true". No Slack notification sent.'
+                else
+                  curl -X POST -H 'Content-type: application/json' --data '{ "attachments": [ { "fallback": "Job completed successfully - '$CIRCLE_BUILD_URL'", "text": "Job has completed successfully", "fields": [ { "title": "Project", "value": "'$CIRCLE_PROJECT_REPONAME'", "short": true }, { "title": "Job Number", "value": "'$CIRCLE_BUILD_NUM'", "short": true } ], "actions": [ { "type": "button", "text": "Visit Job", "url": "'$CIRCLE_BUILD_URL'" } ], "color": "#1CBF43" } ] }' << parameters.webhook >>
+                fi
               else
                 #If Failed
                 curl -X POST -H 'Content-type: application/json' --data '{ "attachments": [ { "fallback": "A job has failed - '$CIRCLE_BUILD_URL'", "text": "A job has failed", "fields": [ { "title": "Project", "value": "'$CIRCLE_PROJECT_REPONAME'", "short": true }, { "title": "Job Number", "value": "'$CIRCLE_BUILD_NUM'", "short": true } ], "actions": [ { "type": "button", "text": "Visit Job", "url": "'$CIRCLE_BUILD_URL'" } ], "color": "#ed5c5c" } ] }' << parameters.webhook >>

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -73,6 +73,7 @@ commands:
               else
                 #If Failed
                 curl -X POST -H 'Content-type: application/json' --data '{ "attachments": [ { "fallback": "A job has failed - '$CIRCLE_BUILD_URL'", "text": "A job has failed", "fields": [ { "title": "Project", "value": "'$CIRCLE_PROJECT_REPONAME'", "short": true }, { "title": "Job Number", "value": "'$CIRCLE_BUILD_NUM'", "short": true } ], "actions": [ { "type": "button", "text": "Visit Job", "url": "'$CIRCLE_BUILD_URL'" } ], "color": "#ed5c5c" } ] }' << parameters.webhook >>
+                echo Job failed. Alert sent.
               fi
             fi
           when: always

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -63,6 +63,7 @@ commands:
             else
               #If successful
               if [ "$SLACK_BUILD_STATUS" = "success" ]; then
+                echo "Fail_Only parameter: << parameters.fail_only >>"
                 if [ << parameters.fail_only >> = "true"]; then
                   echo The job completed successfully
                   echo '"fail_only" is set to "true". No Slack notification sent.'

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -51,6 +51,7 @@ commands:
       - run: 
           name: Slack - Status Alert Sent
           command: |
+            # Provide error if no webhook is set and error. Otherwise continue
             if [ -z "$SLACK_WEBHOOK" ]; then
               echo "NO SLACK WEBHOOK SET"
               echo "Please input your SLACK_WEBHOOK value either in the settings for this project, or as a parameter for this orb."

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
-#slack orb dev:1.1.0
+#slack orb 1.1.0
 #Create your key here: https://api.slack.com/incoming-webhooks
 orbs:
 description: A notification orb for slack. Submit messages to your slack channels.

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -63,7 +63,7 @@ commands:
             else
               #If successful
               if [ "$SLACK_BUILD_STATUS" = "success" ]; then
-                if [ << parameters.webhook >> = "true"]; then
+                if [ << parameters.fail_only >> = "true"]; then
                   echo The job completed successfully
                   echo '"fail_only" is set to "true". No Slack notification sent.'
                 else

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -53,7 +53,7 @@ commands:
             echo 'export SLACK_BUILD_STATUS="success"' >> $BASH_ENV
           when: on_success
       - run: 
-          name: Slack - Status Alert Sent
+          name: Slack - Sending Status Alert
           command: |
             # Provide error if no webhook is set and error. Otherwise continue
             if [ -z "$SLACK_WEBHOOK" ]; then
@@ -63,12 +63,12 @@ commands:
             else
               #If successful
               if [ "$SLACK_BUILD_STATUS" = "success" ]; then
-                echo "Fail_Only parameter: << parameters.fail_only >>"
                 if [ << parameters.fail_only >> = true ]; then
                   echo The job completed successfully
                   echo '"fail_only" is set to "true". No Slack notification sent.'
                 else
                   curl -X POST -H 'Content-type: application/json' --data '{ "attachments": [ { "fallback": "Job completed successfully - '$CIRCLE_BUILD_URL'", "text": "Job has completed successfully", "fields": [ { "title": "Project", "value": "'$CIRCLE_PROJECT_REPONAME'", "short": true }, { "title": "Job Number", "value": "'$CIRCLE_BUILD_NUM'", "short": true } ], "actions": [ { "type": "button", "text": "Visit Job", "url": "'$CIRCLE_BUILD_URL'" } ], "color": "#1CBF43" } ] }' << parameters.webhook >>
+                  echo Job completed successfully. Alert sent.
                 fi
               else
                 #If Failed

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -64,7 +64,7 @@ commands:
               #If successful
               if [ "$SLACK_BUILD_STATUS" = "success" ]; then
                 echo "Fail_Only parameter: << parameters.fail_only >>"
-                if [ << parameters.fail_only >> = "true"]; then
+                if [ << parameters.fail_only >> = true ]; then
                   echo The job completed successfully
                   echo '"fail_only" is set to "true". No Slack notification sent.'
                 else


### PR DESCRIPTION
## 1.1.0: 10/16/2018
* Allow suppression of successful messages with new parameter 'fail_only' when set to 'true'.
* Updated Alert job name to no longer imply the alert has already been sent
* Reflect status in shell as well as webhook
